### PR TITLE
Sync versions of dependencies 📷

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/saguijs/eslint-config-sagui#readme",
   "peerDependencies": {
     "babel-eslint": "6.1.0",
-    "eslint": "3.0.0",
+    "eslint": "2.1.0",
     "eslint-config-standard": "5.3.1",
     "eslint-config-standard-jsx": "1.2.1",
     "eslint-plugin-promise": "1.3.2",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "babel-eslint": "6.1.0",
-    "eslint": "3.0.0",
+    "eslint": "2.1.0",
     "eslint-config-standard": "5.3.1",
     "eslint-config-standard-jsx": "1.2.1",
     "eslint-plugin-promise": "1.3.2",


### PR DESCRIPTION
Because there was desynchronization between the versions of eslint and eslint configs.
