### PR TITLE
Remove `sinon` from list of globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,5 @@ module.exports = {
     jasmine: true
   },
 
-  globals: {
-    sinon: false
-  },
-
   parser: 'babel-eslint'
 }


### PR DESCRIPTION
As of Sagui v7 it is no longer bundled internally.
